### PR TITLE
Add support for Swift 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
         <img src="https://img.shields.io/badge/docker-hub-blue" alt="Vapor images on Docker Hub">
     </a>
     <a href="https://swift.org">
-        <img src="https://img.shields.io/badge/swift-5.2-brightgreen.svg" alt="Swift 5.2">
+        <img src="https://img.shields.io/badge/swift-5.3-brightgreen.svg" alt="Swift 5.3">
     </a>
     <a href="https://twitter.com/codevapor">
         <img src="https://img.shields.io/badge/twitter-codevapor-5AA9E7.svg" alt="Twitter">

--- a/Sources/BuildAndTagScript/ImageSpecifications.swift
+++ b/Sources/BuildAndTagScript/ImageSpecifications.swift
@@ -162,7 +162,7 @@ extension ImageBuilderConfiguration {
     public static var preconfiguredImageSpecifications: Self { return .init(
     
         globalReplacements: [
-            "SWIFT_LATEST_RELEASE_VERSION": "5.2.2", // last updated 04/21/2020
+            "SWIFT_LATEST_RELEASE_VERSION": "5.3", // last updated 2020/10/06
             "SWIFT_BASE_REPO_NAME": "swift",
             "SWIFT_BASE_VERSION": "${SWIFT_VERSION}",
         ],


### PR DESCRIPTION
Sorry if this doesn't trip the right switches to make this work - I'm running through updating dependencies on an older app that I can't update from Vapor 3 due to missing functionality in Vapor 4, and I thought it might be useful/nice to have a Swift 5.3 docker image to work from.